### PR TITLE
fixed deprecation error with node v7, need 'new' keyword in buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,4 +106,4 @@ function isBlob (obj) {
 
 // Workaround Browserify v13 bug
 // https://github.com/substack/node-browserify/issues/1483
-;(function () { Buffer(0) })()
+;(function () { new Buffer(0) })()


### PR DESCRIPTION
Hey sorry to bug you, but I need your module and I'd rather not have to publish a fork to NPM. Everything works great, I just need to use the new keyword around the browserify hack to avoid the deprecation message from v7.

Thanks!