### PR TITLE
parseTorrent.remote: set 30s timeout on http requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function parseTorrentRemote (torrentId, cb) {
     // http, or https url to torrent file
     get.concat({
       url: torrentId,
+      timeout: 30 * 1000,
       headers: { 'user-agent': 'WebTorrent (http://webtorrent.io)' }
     }, function (err, res, torrentBuf) {
       if (err) return cb(new Error('Error downloading torrent: ' + err.message))


### PR DESCRIPTION
So we don't wait forever for an http torrent link to download.